### PR TITLE
fix: ImportResolver reports errors

### DIFF
--- a/go/grammar_import.go
+++ b/go/grammar_import.go
@@ -17,7 +17,7 @@ func NewImportResolver(loader ImportLoader) *ImportResolver {
 func (r *ImportResolver) Resolve(source string) (AstNode, error) {
 	f, err := r.resolve(source, source)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 	return f.Grammar, nil
 }


### PR DESCRIPTION
'file not found' errors are being swallowed by the ImportResolver. I ran into this while making a simple mistake

```go
	resolver := langlang.NewImportResolver(langlang.NewRelativeImportLoader())
	ast, err := resolver.Resolve("../../../../../does/not/exist")
	require.NoError(t, err)
```