### PR TITLE
Included GO wasm_exec copy command and unified build

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -8,7 +8,8 @@
     "react"
   ],
   "scripts": {
-    "build": "bun run --filter @langlang/wasm wasm:build && bun run --filter '*' build"
+    "build": "bun run --filter @langlang/wasm wasm:build && bun run --filter '*' build",
+    "playground": "bun run --filter @langlang/web-test dev"
   },
   "devDependencies": {
     "prettier": "^3.7.4"

--- a/js/package.json
+++ b/js/package.json
@@ -7,6 +7,9 @@
     "web",
     "react"
   ],
+  "scripts": {
+    "build": "bun run --filter @langlang/wasm wasm:build && bun run --filter '*' build"
+  },
   "devDependencies": {
     "prettier": "^3.7.4"
   }

--- a/js/wasm/README.md
+++ b/js/wasm/README.md
@@ -14,7 +14,7 @@ bun run src/index.ts
 
 ## Building the Go WASM binary (no Makefile needed)
 
-This package uses `package.json` scripts (shell commands) that replace `make build/clean/tidy`:
+This package uses `package.json` scripts (shell commands) that replace `make build/clean/tidy/copy`:
 
 ```bash
 # Build src/langlang.wasm and copy it into dist/langlang.wasm
@@ -25,6 +25,9 @@ bun run wasm:clean
 
 # Run `go mod tidy` inside ./lib
 bun run wasm:tidy
+
+# Copy wasm_exec.js from Go's GOROOT into src/wasm_exec.js
+bun run wasm:copy
 ```
 
 ## Idiomatic JS API (Matcher / Tree / Node)

--- a/js/wasm/package.json
+++ b/js/wasm/package.json
@@ -22,9 +22,10 @@
   "scripts": {
     "build": "tsc && cp src/wasm_exec.js dist/wasm_exec.js && cp src/langlang.wasm dist/langlang.wasm",
     "dev": "tsc --watch",
-    "wasm:build": "mkdir -p src dist && cd lib && GOWORK=off GOOS=js GOARCH=wasm go build -o ../src/langlang.wasm . && cd .. && cp src/langlang.wasm dist/langlang.wasm",
+    "wasm:build": "mkdir -p src dist && bun run wasm:copy && cd lib && GOWORK=off GOOS=js GOARCH=wasm go build -o ../src/langlang.wasm . && cd .. && cp src/langlang.wasm dist/langlang.wasm",
     "wasm:clean": "rm -f src/langlang.wasm dist/langlang.wasm",
     "wasm:tidy": "cd lib && go mod tidy",
+    "wasm:copy": "cp \"$(go env GOROOT)/misc/wasm/wasm_exec.js\" src/wasm_exec.js",
     "prepublishOnly": "bun run build"
   },
   "devDependencies": {


### PR DESCRIPTION
This pull request updates the build process for the WASM package to better automate copying the necessary Go runtime file and clarifies the documentation accordingly. The most important changes are grouped below:

**Build process improvements:**

* Added a new `wasm:copy` script to `js/wasm/package.json` that copies `wasm_exec.js` from Go's GOROOT into `src/wasm_exec.js` to ensure the correct runtime file is present.
* Updated the `wasm:build` script in `js/wasm/package.json` to run the new `wasm:copy` step before building the WASM binary.
* Added a top-level `build` script to `js/package.json` to coordinate building the WASM package and any other packages.

**Documentation updates:**

* Updated `js/wasm/README.md` to mention the new `wasm:copy` script as part of the build and setup process, and provided an example usage. [[1]](diffhunk://#diff-413a0b3649cfb3f8af6b37a5d5e47a81fbd01a68c58c89e06046d9be056d2205L17-R17) [[2]](diffhunk://#diff-413a0b3649cfb3f8af6b37a5d5e47a81fbd01a68c58c89e06046d9be056d2205R28-R30)